### PR TITLE
Output should be key~value pairs, not value~key pairs

### DIFF
--- a/src/Chevalier.hs
+++ b/src/Chevalier.hs
@@ -62,9 +62,9 @@ chevalier chevalier_url query_mvar =
         in LazyBuilder.toLazyText builder
       where
         f acc (SourceTag k v) = acc
-            <> (LazyBuilder.fromText $ getField v)
-            <> "~"
             <> (LazyBuilder.fromText $ getField k)
+            <> "~"
+            <> (LazyBuilder.fromText $ getField v)
             <> ","
 
     buildChevalierRequest (SourceQuery q page _ ) = SourceRequest


### PR DESCRIPTION
Switch the order to generate more sensicle names
