### PR TITLE
Rename "descartes" to "sieste"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 dist/
 log/
+*.hi
+*.o

--- a/sieste.cabal
+++ b/sieste.cabal
@@ -1,4 +1,4 @@
-Name:                descartes
+Name:                sieste
 Version:             0.1
 Synopsis:            REST interface to vaultaire and chevalier
 Description:         REST interface to vaultaire and chevalier
@@ -10,7 +10,7 @@ Category:            Web
 Build-type:          Simple
 Cabal-version:       >=1.2
 
-Executable descartes
+Executable sieste
   hs-source-dirs: src
   main-is: Main.hs
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -5,11 +5,11 @@ import           Control.Applicative
 import           Control.Concurrent
 import           Control.Concurrent.Async
 import           Control.Monad
-import           Descartes.Chevalier      (chevalier)
-import           Descartes.Interpolated   (interpolated)
-import           Descartes.Raw            (raw)
-import           Descartes.ReaderD        (readerd)
-import           Descartes.SimpleSearch   (simpleSearch)
+import           Sieste.Chevalier      (chevalier)
+import           Sieste.Interpolated   (interpolated)
+import           Sieste.Raw            (raw)
+import           Sieste.ReaderD        (readerd)
+import           Sieste.SimpleSearch   (simpleSearch)
 import           Snap.Core
 import           Snap.Http.Server
 import           System.Environment       (getEnv)
@@ -55,5 +55,5 @@ main = do
 
     docString = "<html>This is the Vaultaire REST interface, you can find \
                 \documentation in the wiki under <a href=\"\
-               \https://docs.anchor.net.au/system/vaultaire/Descartes\">\
-               \system/vaultaire/Descartes</a></html>"
+               \https://docs.anchor.net.au/system/vaultaire/Sieste\">\
+               \system/vaultaire/Sieste</a></html>"

--- a/src/Sieste/Chevalier.hs
+++ b/src/Sieste/Chevalier.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Descartes.Chevalier where
+module Sieste.Chevalier where
 
 import           Control.Concurrent
 import           Control.Exception
@@ -9,7 +9,7 @@ import           Data.Serialize
 import           Data.Text.Encoding        (decodeUtf8, encodeUtf8)
 import qualified Data.Text.Lazy            as LT
 import qualified Data.Text.Lazy.Builder    as LazyBuilder
-import           Descartes.Types.Chevalier
+import           Sieste.Types.Chevalier
 import           Snap.Core                 (urlEncode)
 import           System.Timeout            (timeout)
 import           System.ZMQ4               hiding (source)

--- a/src/Sieste/Interpolated.hs
+++ b/src/Sieste/Interpolated.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE PatternGuards       #-}
 {-# LANGUAGE RecordWildCards     #-}
 
-module Descartes.Interpolated where
+module Sieste.Interpolated where
 
 import           Control.Applicative
 import           Control.Concurrent           hiding (yield)
@@ -11,9 +11,9 @@ import           Control.Monad.IO.Class
 import           Data.ByteString.Lazy.Builder (stringUtf8)
 import           Data.ProtocolBuffers         (getField)
 import           Data.Word                    (Word64)
-import           Descartes.Types.ReaderD      (DataFrame (..), RangeQuery (..),
+import           Sieste.Types.ReaderD      (DataFrame (..), RangeQuery (..),
                                                ValueType (..))
-import           Descartes.Util
+import           Sieste.Util
 import           Pipes
 import           Pipes.Concurrent
 import           Snap.Core

--- a/src/Sieste/Raw.hs
+++ b/src/Sieste/Raw.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-module Descartes.Raw where
+module Sieste.Raw where
 
 import           Control.Concurrent           hiding (yield)
 import           Control.Monad.IO.Class
 import           Data.ByteString.Lazy.Builder (stringUtf8)
-import           Descartes.Types.ReaderD      (RangeQuery (..))
-import           Descartes.Util
+import           Sieste.Types.ReaderD      (RangeQuery (..))
+import           Sieste.Util
 import           Pipes
 import           Pipes.Concurrent
 import           Snap.Core

--- a/src/Sieste/ReaderD.hs
+++ b/src/Sieste/ReaderD.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
-module Descartes.ReaderD where
+module Sieste.ReaderD where
 
 import           Codec.Compression.LZ4   (decompress)
 import           Control.Applicative     ((<$>))
@@ -10,7 +10,7 @@ import qualified Data.ByteString         as B
 import           Data.ProtocolBuffers    hiding (field)
 import           Data.Serialize          (runGet, runPut)
 import           Data.Text.Encoding      (encodeUtf8)
-import           Descartes.Types.ReaderD
+import           Sieste.Types.ReaderD
 import           Pipes
 import           Pipes.Concurrent        (toOutput, performGC)
 import           System.ZMQ4

--- a/src/Sieste/SimpleSearch.hs
+++ b/src/Sieste/SimpleSearch.hs
@@ -1,14 +1,14 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-module Descartes.SimpleSearch where
+module Sieste.SimpleSearch where
 
 import           Control.Applicative
 import           Control.Concurrent           hiding (yield)
 import           Control.Monad.IO.Class
 import           Data.ByteString.Lazy.Builder (stringUtf8)
 import           Data.Maybe
-import           Descartes.Types.Chevalier    (SourceQuery (..))
-import           Descartes.Util
+import           Sieste.Types.Chevalier    (SourceQuery (..))
+import           Sieste.Util
 import           Snap.Core
 import           System.Timeout               (timeout)
 

--- a/src/Sieste/Types/Chevalier.hs
+++ b/src/Sieste/Types/Chevalier.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
 
-module Descartes.Types.Chevalier where
+module Sieste.Types.Chevalier where
 
 import           Control.Concurrent
 import           Control.Exception

--- a/src/Sieste/Types/ReaderD.hs
+++ b/src/Sieste/Types/ReaderD.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE RecordWildCards      #-}
 
-module Descartes.Types.ReaderD where
+module Sieste.Types.ReaderD where
 
 import           Control.Exception
 import qualified Data.Aeson             as A

--- a/src/Sieste/Types/Util.hs
+++ b/src/Sieste/Types/Util.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings  #-}
 
-module Descartes.Types.Util where
+module Sieste.Types.Util where
 
 import           Data.Aeson           (ToJSON, object, toJSON, (.=))
 import qualified Data.Text.Lazy       as LT

--- a/src/Sieste/Util.hs
+++ b/src/Sieste/Util.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Descartes.Util where
+module Sieste.Util where
 import           Control.Applicative
 import           Control.Exception            (SomeException)
 import           Control.Monad
@@ -17,9 +17,9 @@ import           Data.Text                    (Text)
 import           Data.Text.Encoding           (decodeUtf8')
 import           Data.Text.Lazy.Encoding      (decodeUtf8)
 import           Data.Word                    (Word64)
-import           Descartes.Types.ReaderD      (DataBurst (..), DataFrame (..),
+import           Sieste.Types.ReaderD      (DataBurst (..), DataFrame (..),
                                                SourceTag (..))
-import           Descartes.Types.Util
+import           Sieste.Types.Util
 import           Pipes
 import qualified Pipes.Prelude                as Pipes
 import           Snap.Core


### PR DESCRIPTION
Due to the overloaded nature of the name "descartes", rename the project to "sieste"

etymology: French (borrowed from the Spanish) for "afternoon nap", and since this is the Vaultaire REST interface, it totally works. 

Pending merge, the github project will also have to be renamed, as well as documentation nodes and other bits and pieces. 
