### PR TITLE
Split query value into tokenized fields

### DIFF
--- a/src/Sieste/Chevalier.hs
+++ b/src/Sieste/Chevalier.hs
@@ -107,7 +107,7 @@ chevalier chevalier_url query_mvar =
 
     buildTags q =
         let values = splitOn wildcard q
-        in [ SourceTag { field = putField wildcard, value = putField (wrap a)} | a <- values ]
-        where
-            wildcard = "*"
-            wrap v =  append wildcard $ append v $ wildcard
+        in  [SourceTag { field = putField wildcard, value = putField (wrap a)} | a <- values ]
+      where
+        wildcard = "*"
+        wrap v =  append wildcard $ append v $ wildcard


### PR DESCRIPTION
If a query comes in with instring asterisks, split it into separate
{field:any value:x} chevalier calls.

Allows for combination searching (not limited to order of keys) now that
there aren't any string concatenation indexes.
