### PR TITLE
Travis update and version bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: haskell
 env:
-  - 'UBUNTU_RELEASE=saucy GHCVER=7.8.2 CABALVER=1.20'
   - 'UBUNTU_RELEASE=saucy GHCVER=7.8.3 CABALVER=1.20'
 
 before_install:

--- a/sieste.cabal
+++ b/sieste.cabal
@@ -1,5 +1,5 @@
 Name:                sieste
-Version:             0.3.2
+Version:             0.4.0
 Synopsis:            REST interface to vaultaire and chevalier
 Description:         REST interface to vaultaire and chevalier
 License:             BSD3


### PR DESCRIPTION
General housekeeping

anchor/sieste@c9cf556 introduced functionality that should have gotten a version bump. Has been applied. 

Travis is still building against 7.8.2 which is horrible and known to have issues. Remove from travis build matrix. 