### PR TITLE
Correct build dependency errors with upper bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ REST interface to vaultaire
 ## Role
 To provide abstractions of all things Vaultaire related to consumers over HTTP and JSON.
 
-
 ## Current coverage
 ### /simple/search
 A simple interface to [Chevalier](https://github.com/anchor/chevalier), options avaliable are:

--- a/sieste.cabal
+++ b/sieste.cabal
@@ -22,6 +22,8 @@ Executable sieste
     snap-core                 >= 0.9   && < 0.11,
     snap-server               >= 0.9   && < 0.11,
     aeson                     >= 0.7,
+    transformers-compat       >= 0.3   && < 0.4,
+    blaze-builder             >= 0.3   && < 0.4,
     cereal,
     marquise,
     async,


### PR DESCRIPTION
set upperbounds to prevent clash with transformers-compa/optparse-applicative and blaze-builder/streaming-commons
